### PR TITLE
procarg: unbound variable

### DIFF
--- a/share/pentoo-installer/gauge_unsquashfs
+++ b/share/pentoo-installer/gauge_unsquashfs
@@ -33,6 +33,7 @@ readonly SHAREDIR="$(dirname ${0})" || exit $?
 source "${SHAREDIR}"/common.sh || exit $?
 
 #we export RAMSIZE from pentoo-installer, so hopefully we can use it here
+procarg=
 if [ "${RAMSIZE}" -le "1500" ]; then
   procarg="-p 1"
 fi


### PR DESCRIPTION
This broke the installer unless RAMSIZE was below 1500.
Unbound vars seem to throw errors ...