### PR TITLE
Fix for #26: Wrong permission on /var/lib

### DIFF
--- a/share/pentoo-installer/copy_distro
+++ b/share/pentoo-installer/copy_distro
@@ -244,7 +244,7 @@ show_dialog_rsync '-av --progress' \
   "/var/log/*" "${DESTDIR}/var/log/" "Syncing logs ..." || exit $?
 if [ -d "/mnt/overlay/.upper/var/lib/NetworkManager" ]; then
   show_dialog_rsync '-av --progress' \
-    "/var/lib/NetworkManager/" "${DESTDIR}/var/lib/" "Syncing NetworkManager config ..." || exit $?
+    "/var/lib/NetworkManager" "${DESTDIR}/var/lib/" "Syncing NetworkManager config ..." || exit $?
 fi
 if [ -d "/mnt/overlay/.upper/var/lib/gentoo/news" ]; then
   show_dialog_rsync '-av --progress' \

--- a/share/pentoo-installer/copy_distro
+++ b/share/pentoo-installer/copy_distro
@@ -248,11 +248,11 @@ if [ -d "/mnt/overlay/.upper/var/lib/NetworkManager" ]; then
 fi
 if [ -d "/mnt/overlay/.upper/var/lib/gentoo/news" ]; then
   show_dialog_rsync '-av --progress' \
-    "/var/lib/gentoo/news/" "${DESTDIR}/var/lib/gentoo/" "Syncing Gentoo News ..." || exit $?
+    "/var/lib/gentoo/news" "${DESTDIR}/var/lib/gentoo/" "Syncing Gentoo News ..." || exit $?
 fi
 if [ -d "/mnt/overlay/.upper/var/lib/dhcpcd" ]; then
   show_dialog_rsync '-av --progress' \
-    "/var/lib/dhcpcd/" "${DESTDIR}/var/lib/" "Syncing dhcpcd config ..." || exit $?
+    "/var/lib/dhcpcd" "${DESTDIR}/var/lib/" "Syncing dhcpcd config ..." || exit $?
 fi
 if [ -d "/mnt/overlay/.upper/usr/portage" ]; then
   show_dialog_rsync '-av --progress' \


### PR DESCRIPTION
After (hardened) installation, 'emerge xyz' will fail due to 'Permission denied'.
The problem is wrong permission on /var/lib - it is 700 instead of 755.

I tracked it down to the rsync of Networkmanager, removing the slash after the source solved the permission issue.
Logically, the other 2 rsync in this PR are wrong too.
Tested on 2018 RC 7.2 - works here.

Sidenote:
I was having a strange issue with ghost ./var/lib/news folders popping up in random places. Maybe this PR fixes that too, let's see.