### PR TITLE
Always export variables vm and vm_from

### DIFF
--- a/share/pentoo-installer/pentoo-installer
+++ b/share/pentoo-installer/pentoo-installer
@@ -127,8 +127,8 @@ checkvm() {
 		fi
 	fi
 
-  [ -n "${vm}" ] && export vm
-  [ -n "${vm_from}" ] && export vm_from
+  export vm
+  export vm_from
 }
 
 #####################
@@ -161,6 +161,8 @@ if [ "${RAMSIZE}" -le "1500" ]; then
     show_dialog --msgbox "WARNING: the install speed will be reduced due to the low system RAM." 0 0
   fi
 fi
+[ -z "${vm+x}" ] && export vm=
+[ -z "${vm_from+x}" ] && export vm_from=
 
 if [ "$(equery --quiet list pentoo/pentoo-installer 2> /dev/null)" = "pentoo/pentoo-installer-99999999" ]; then
 


### PR DESCRIPTION
The installer fails on unbound variables, from the logs:
/usr/share/pentoo-installer/copy_distro: line 327: vm: unbound variable
Fix for #37 

Tested on vbox (4G ram).
This is a hotfix - feel free to implement a better solution!