### PR TITLE
New feature: Headless mode

### DIFF
--- a/sbin/pentoo-installer
+++ b/sbin/pentoo-installer
@@ -1,2 +1,2 @@
 #!/bin/bash
-/usr/share/pentoo-installer/pentoo-installer 2> /tmp/pentoo-installer.log
+/usr/share/pentoo-installer/pentoo-installer "${@}" 2> /tmp/pentoo-installer.log

--- a/share/pentoo-installer/bootloader_grub2
+++ b/share/pentoo-installer/bootloader_grub2
@@ -181,8 +181,10 @@ fi
 # set system editor (if not already defined)
 chroot_mount || exit $?
 EDITOR="$(geteditor)" || exit $?
-# let user edit grub menu file
-"${EDITOR}" "${GRUBCONFIG}" || exit $?
+# let user edit grub menu file (skipped for headless mode)
+if [ -z "${INSTALLER_HEADLESS:-}" ]; then
+	"${EDITOR}" "${GRUBCONFIG}" || exit $?
+fi
 
 #maybe move the stat check a LOT earlier?
 if [ -d /sys/firmware/efi ]; then

--- a/share/pentoo-installer/common.sh
+++ b/share/pentoo-installer/common.sh
@@ -463,7 +463,7 @@ show_dialog() {
 		elif [ -n "${_DEFAULTVALUE}" ]; then
 			_ANSWER="${_DEFAULTVALUE}"
 		elif [ "${_DIALOGBOX}" == '--calendar' ]; then
-			_ANSWER="$(date +'%m/%d/%Y')" || exit $?
+			_ANSWER="$(date +'%d/%m/%Y')" || exit $?
 		elif [ "${_DIALOGBOX}" == '--timebox' ]; then
 			_ANSWER="$(date +'%T')" || exit $?
 		# inputbox without default value, catch timeout

--- a/share/pentoo-installer/common.sh
+++ b/share/pentoo-installer/common.sh
@@ -198,7 +198,7 @@ get_yesno() {
 # arguments (required):
 #  _DISCLIST: List of involved discs or partitions
 #
-# exits: !=1 is an error
+# exits: !=0 is an error
 #
 mount_umountall() {
 	# check input
@@ -466,6 +466,12 @@ show_dialog() {
 			_ANSWER="$(date +'%m/%d/%Y')" || exit $?
 		elif [ "${_DIALOGBOX}" == '--timebox' ]; then
 			_ANSWER="$(date +'%T')" || exit $?
+		# inputbox without default value, catch timeout
+		elif [ "${_DIALOGBOX}" == '--inputbox' ]; then
+			if [ "${_ANSWER}" == $'\ntimeout' ]; then
+				echo "Error: input box in headless mode without default returned timeout" 1>&2
+				exit 1
+			fi
 		fi
 	# check if user clicked cancel or closed the box
 	elif [ "${_DIALOGRETURN}" -eq "1" ] || [ "${_DIALOGRETURN}" -eq "255" ]; then

--- a/share/pentoo-installer/common.sh
+++ b/share/pentoo-installer/common.sh
@@ -51,7 +51,7 @@ add_option_label() {
 # catch errors from sub-script/functions
 #
 # returns 0 when an error was given
-# otherwise returns 0
+# otherwise returns 1
 #
 # parameters (required):
 #  _FUNCNAME: name of calling function/script

--- a/share/pentoo-installer/common.sh
+++ b/share/pentoo-installer/common.sh
@@ -402,7 +402,7 @@ show_dialog() {
 		elif [ -n "${INSTALLER_HEADLESS:-}" ] && [ "${_ARGUMENTS[$_INDEX]}" == '--defaultno' ]; then
 			_ARGUMENTS[$_INDEX]='--nocancel'
 		elif [ "${_ARGUMENTS[$_INDEX]}" == '--inputbox' ]; then
-			if [ "$((${_INDEX}+4))" -le "${#_ARGUMENTS[@]}" ]; then
+			if [ "$((${_INDEX}+4))" -lt "${#_ARGUMENTS[@]}" ]; then
 				_DEFAULTVALUE="${_ARGUMENTS[$((_INDEX+4))]}" || exit $?
 			fi
 		elif [ "${_ARGUMENTS[$_INDEX]}" == '--menu' ]; then

--- a/share/pentoo-installer/configure_system
+++ b/share/pentoo-installer/configure_system
@@ -124,6 +124,7 @@ EOF
 check_num_args "$(basename $0)" 1 $# || exit $?
 CONFIG_LIST="${1}"
 EDITOR=
+DEFAULTITEM=
 MENU_ITEMS=
 NEWSELECTION=
 USERNAME=
@@ -151,8 +152,12 @@ MENU_ITEMS=("Editor"				"System Editor" \
 			"DONE"			"Return to Main Menu" )
 
 while true; do
+	# shortcut for headless mode
+	if [ -n "${INSTALLER_HEADLESS:-}" ]; then
+		DEFAULTITEM='--default-item DONE'
+	fi
 	# expand menu items array below
-	NEWSELECTION="$(show_dialog --menu "Configuration" \
+	NEWSELECTION="$(show_dialog ${DEFAULTITEM} --menu "Configuration" \
 		0 0 0 "${MENU_ITEMS[@]}")" || exit $?
 	# call subscript by selected item
 	case "${NEWSELECTION}" in

--- a/share/pentoo-installer/partition_mainmenu
+++ b/share/pentoo-installer/partition_mainmenu
@@ -103,9 +103,14 @@ while true; do
 	# handle errors from sub-script/functions using a common utility function
 	if ! catch_menuerror "$(basename $0)" "${NEWSELECTION}" "${RETSUB}"; then
 		# everything ok, increase selection for next menu item
-		# jump from auto-prepare directly to mountpoints
 		if [ "${SELECTION}" -eq 0 ]; then
-			SELECTION=2
+			if [ -n "${INSTALLER_HEADLESS:-}" ]; then
+				# jump from auto-prepare directly to create-FS and exit (headless mode)
+				SELECTION=3
+			else
+				# jump from auto-prepare directly to mountpoints
+				SELECTION=2
+			fi
 		else
 			SELECTION="$((NEWSELECTION+1))" || exit $?
 		fi

--- a/share/pentoo-installer/pentoo-installer
+++ b/share/pentoo-installer/pentoo-installer
@@ -136,6 +136,23 @@ checkvm() {
 #####################
 ## begin execution ##
 
+# INSTALLER_HEADLESS: emtpy=false
+export INSTALLER_HEADLESS=
+
+# check passed arguments
+while [[ $# -gt 0 ]]; do
+  case "${1}" in
+    --headless)
+      export INSTALLER_HEADLESS=1
+      shift
+      ;;
+    *)    # unknown option
+      show_dialog --msgbox "ERROR: Unknown option '${1}'. Aborting with  error." 0 0
+      printf "ERROR: Unknown option '${1}'. Aborting with error." 1>&2 && exit 1
+      ;;
+  esac
+done
+
 # display welcome txt depending on used dialog
 WHICHDIALOG="$(get_dialog)"
 

--- a/share/pentoo-installer/settzclock
+++ b/share/pentoo-installer/settzclock
@@ -46,7 +46,7 @@ sed -Ei 's#^clock="[^"]*"$#clock="'"${HARDWARECLOCK:0:5}"'"#' /etc/conf.d/hwcloc
 # the sed commands make the few necessary changes
 cp /usr/bin/tzselect /tmp/tzselect.patched \
 	&& sed -i 's#^\t+#\t*#' /tmp/tzselect.patched \
-	&& patch --silent /tmp/tzselect.patched -i "${SHAREDIR}"/timezone-data-2015e-dialog.patch
+	&& patch --silent /tmp/tzselect.patched -i "${SHAREDIR}"/timezone-data-2018d-dialog.patch
 	TIMEZONE="$(SHOWDIALOG="${SHAREDIR}"/tzselect_dialog /tmp/tzselect.patched)" \
 	&& rm /tmp/tzselect.patched \
 	|| exit $?

--- a/share/pentoo-installer/settzclock
+++ b/share/pentoo-installer/settzclock
@@ -55,6 +55,7 @@ cp /usr/bin/tzselect /tmp/tzselect.patched \
 if [ "${TIMEZONE}" != "" -a -e "/usr/share/zoneinfo/${TIMEZONE}" ]; then
 	echo "setting timezone to: ${TIMEZONE}" 1>&2
 	echo "${TIMEZONE}" > /etc/timezone
+	emerge --config sys-libs/timezone-data || exit $?
 fi
 
 # display and ask to set date/time

--- a/share/pentoo-installer/timezone-data-2018d-dialog.patch
+++ b/share/pentoo-installer/timezone-data-2018d-dialog.patch
@@ -1,8 +1,8 @@
 based on original work by wuodan here:
-https://github.com/Wuodan/tz/commit/5297b9ca06f79c334b9492713ce388b590e436e3
+https://github.com/Wuodan/tz
 
---- tzselect.patched	2015-09-19 23:23:37.357786123 -0400
-+++ tzselect.patched2	2015-09-19 23:49:50.395684504 -0400
+--- tzselect.patched
++++ tzselect.patched
 @@ -36,6 +36,7 @@
  # Specify default values for environment variables if they are unset.
  : ${AWK=awk}
@@ -127,35 +127,39 @@ https://github.com/Wuodan/tz/commit/5297b9ca06f79c334b9492713ce388b590e436e3
  		"coord - I want to use geographical coordinates." \
 -		"TZ - I want to specify the time zone using the Posix TZ format."
 -	    continent=$select_result
-+		"TZ - I want to specify the time zone using the Posix TZ format."` || exit $?
++		"TZ - I want to specify the timezone using the Posix TZ format."` || exit $?
  	    case $continent in
  	    Americas) continent=America;;
  	    *" "*) continent=`expr "$continent" : '\''\([^ ]*\)'\''`
-@@ -340,11 +382,9 @@
+@@ -340,13 +382,10 @@
  	TZ)
  		# Ask the user for a Posix TZ string.  Check that it conforms.
  		while
 -			echo >&2 'Please enter the desired value' \
 -				'of the TZ environment variable.'
--			echo >&2 'For example, GST-10 is a zone named GST' \
--				'that is 10 hours ahead (east) of UTC.'
+-			echo >&2 'For example, AEST-10 is a zone named AEST' \
+-				'that is 10 hours'
+-			echo >&2 'ahead (east) of Greenwich,' \
+-				'with no daylight saving time.'
 -			read TZ
 +			TZ=`"${SHOWDIALOG}" inputbox \
 +				'Please enter the desired value of the TZ environment variable.
-+For example, GST-10 is a zone named GST that is 10 hours ahead (east) of UTC.'` || exit $?
++For example, AEST-10 is abbreviated AEST and is 10 hours
++ahead (east) of Greenwich, with no daylight saving time.'` || exit $?
  			$AWK -v TZ="$TZ" 'BEGIN {
- 				tzname = "[^-+,0-9][^-+,0-9][^-+,0-9]+"
- 				time = "[0-2]?[0-9](:[0-5][0-9](:[0-5][0-9])?)?"
-@@ -357,7 +397,7 @@
+ 				tzname = "(<[[:alnum:]+-]{3,}>|[[:alpha:]]{3,})"
+ 				time = "(2[0-4]|[0-1]?[0-9])" \
+@@ -362,7 +401,8 @@
  				exit 0
  			}'
  		do
 -		    say >&2 "'$TZ' is not a conforming Posix time zone string."
-+			"${SHOWDIALOG}" msgbox "'$TZ' is not a conforming Posix time zone string."
++			"${SHOWDIALOG}" msgbox \
++				"'$TZ' is not a conforming Posix time zone string."
  		done
  		TZ_for_date=$TZ;;
  	*)
-@@ -365,12 +405,10 @@
+@@ -370,12 +410,10 @@
  		coord)
  		    case $coord in
  		    '')
@@ -172,7 +176,7 @@ https://github.com/Wuodan/tz/commit/5297b9ca06f79c334b9492713ce388b590e436e3
  		    esac
  		    distance_table=`$AWK \
  			    -v coord="$coord" \
-@@ -383,12 +421,10 @@
+@@ -388,13 +426,11 @@
  		      BEGIN { FS = "\t" }
  		      { print $NF }
  		    '`
@@ -182,14 +186,16 @@ https://github.com/Wuodan/tz/commit/5297b9ca06f79c334b9492713ce388b590e436e3
 -			    "of distance from $coord".
 -		    doselect $regions
 -		    region=$select_result
+-		    TZ=`say "$distance_table" | $AWK -v region="$region" '
 +		    region=`"${SHOWDIALOG}" menu \
-+		    "Please select one of the following time zone regions,
++		      "Please select one of the following timezones,
 +listed roughly in increasing order of distance from $coord." \
-+		    $regions` || exit $?
- 		    TZ=`say "$distance_table" | $AWK -v region="$region" '
++		      $regions` || exit $?
++		    TZ=`echo "$distance_table" | $AWK -v region="$region" '
  		      BEGIN { FS="\t" }
  		      $NF == region { print $4 }
-@@ -425,10 +461,9 @@
+ 		    '`
+@@ -430,10 +466,9 @@
  		# If there's more than one country, ask the user which one.
  		case $countries in
  		*"$newline"*)
@@ -203,7 +209,7 @@ https://github.com/Wuodan/tz/commit/5297b9ca06f79c334b9492713ce388b590e436e3
  		*)
  			country=$countries
  		esac
-@@ -457,10 +492,9 @@
+@@ -462,10 +497,9 @@
  		# If there's more than one region, ask the user which one.
  		case $regions in
  		*"$newline"*)
@@ -212,23 +218,23 @@ https://github.com/Wuodan/tz/commit/5297b9ca06f79c334b9492713ce388b590e436e3
 -			doselect $regions
 -			region=$select_result;;
 +			region=`"${SHOWDIALOG}" menu \
-+				'Please select one of the following time zone regions.' \
++				'Please select one of the following timezones.' \
 +				$regions` || exit $?;;
  		*)
  			region=$regions
  		esac
-@@ -518,22 +552,24 @@
+@@ -522,23 +556,24 @@
+ 
  
  	# Output TZ info and ask the user to confirm.
- 
--	echo >&2 ""
--	echo >&2 "The following information has been given:"
--	echo >&2 ""
 +	infomsg='
 +The following information has been given:
 +
 +'
-+
+ 
+-	echo >&2 ""
+-	echo >&2 "The following information has been given:"
+-	echo >&2 ""
  	case $country%$region%$coord in
 -	?*%?*%)	say >&2 "	$country$newline	$region";;
 -	?*%%)	say >&2 "	$country";;
@@ -239,7 +245,7 @@ https://github.com/Wuodan/tz/commit/5297b9ca06f79c334b9492713ce388b590e436e3
 +	?*%%)   infomsg="${infomsg}     $country";;
 +	%?*%?*) infomsg="${infomsg}     coord $coord$newline    $region";;
 +	%%?*)   infomsg="${infomsg}     coord $coord";;
-+	*)              infomsg="${infomsg}     TZ='$TZ'"
++	*)      infomsg="${infomsg}     TZ='$TZ'"
  	esac
 -	say >&2 ""
 -	say >&2 "Therefore TZ='$TZ' will be used.$extra_info"


### PR DESCRIPTION
The first 4 commits are already in #40.

**Headless mode:**
I think you will like this. In a VM, simply run:

> pentoo-installer --headless

and enjoy the show! Each menu has a timeout of 3 seconds and the installer steps through to the end!

This enables fully automated testing of the installer, for example with packer/vagrant/vbox, see:
https://github.com/wuodan/pentoo-packer
where I run 3 installations in parallel (rc7.2, rc7.2 low ram, latest beta).
Already found 2 bugs this way :-)

It's not running from a config file yet (#34), but this is a big step towards it.
