### PR TITLE
Run headless from config-file

### DIFF
--- a/config-samples/config.bios.msdos.json
+++ b/config-samples/config.bios.msdos.json
@@ -1,0 +1,116 @@
+{
+	"#": "optional (utc or localtime)",
+	"hwclock": "utc",
+
+	"#": "optional",
+	"timezone": "Europe/Zurich",
+
+	"#": "required",
+	"disks":[
+		{
+			"#": "required",
+			"device": "/dev/sda",
+
+			"#": "optional: will only be applied when set and different from current (msdos/gpt)",
+			"#": "requires wipe=true",
+			"partition-table": "msdos",
+
+			"#": "optional default=false",
+			"wipe": true,
+
+			"#": "required",
+			"partitions": [
+				{
+					"#": "semi-required: either 'create' or 'existing' must be present",
+					"create": {
+						"#": "optional (default=primary) for msdos: primary/extended/logical",
+						"#": "list extended before logical and only one extended per disk!",
+						"partition-type": "primary",
+
+						"#": "required",
+						"start": "1",
+
+						"#": "anything that parted understands",
+						"end": "129M",
+
+						"#": "optional",
+						"flags": {
+							"#": "anything that parted understands",
+							"boot": "on"
+						}
+					},
+
+					"#": "semi-required: either 'create' or 'existing' must be present",
+					"#": "below key is prepended with '#', since it's just an example!",
+					"#existing": {
+						"#": "required",
+						"device": "/dev/sda1",
+
+						"#": "optional, default=false",
+						"format": false
+					},
+
+					"#": "required: must be empty for swap",
+					"#": "ignored for msdos logical partitions",
+					"mountpoint": "/boot",
+
+					"#": "optional, default='' (one of: 'swap', 'luks', 'luks-gpg', '')",
+					"crypttype": "",
+
+					"#": "required",
+					"#": "ignored for msdos logical partitions",
+					"filesystem": "ext4-nojournal",
+
+					"#": "optional (default=false): maximise into free space",
+					"want_maximised": true
+				},
+				{
+					"create": {
+						"start": "129M",
+						"end": "1281M"
+					},
+					"mountpoint": "",
+					"filesystem": "swap",
+					"want_maximised": true
+				},
+				{
+					"create": {
+						"start": "1281M",
+						"end": "54G"
+					},
+					"mountpoint": "/",
+					"filesystem": "ext4",
+					"want_maximised": true
+				},
+				{
+					"create": {
+						"partition-type": "extended",
+						"start": "54G",
+						"end": "64G"
+					},
+					"want_maximised": true
+				},
+				{
+					"create": {
+						"partition-type": "logical",
+						"start": "54G",
+						"end": "60G"
+					},
+					"mountpoint": "/mnt/logical1",
+					"filesystem": "ext4",
+					"want_maximised": true
+				},
+				{
+					"create": {
+						"partition-type": "logical",
+						"start": "60G",
+						"end": "64G"
+					},
+					"mountpoint": "/mnt/logical2",
+					"filesystem": "ext4",
+					"want_maximised": true
+				}
+			]
+		}
+	]
+}

--- a/config-samples/config.bios.msdos.withexisting.json
+++ b/config-samples/config.bios.msdos.withexisting.json
@@ -1,0 +1,99 @@
+{
+	"#": "optional (utc or localtime)",
+	"hwclock": "utc",
+
+	"#": "optional",
+	"timezone": "Europe/Zurich",
+
+	"#": "required",
+	"disks":[
+		{
+			"#": "required",
+			"device": "/dev/sda",
+			"#": "optional: will only be applied when set and different from current (msdos/gpt)",
+			"#": "requires wipe=true",
+			"partition-table": "msdos",
+			"#": "optional default=false",
+			"wipe": false,
+			"#": "required",
+			"partitions": [
+				{
+					"#": "semi-required: either 'create' or 'existing' must be present",
+					"create": {
+						"#": "optional (default=primary) for msdos: primary/extended/logical",
+						"#": "list extended before logical and only one extended per disk!",
+						"partition-type": "primary",
+						"#": "required",
+						"start": "1",
+						"#": "anything that parted understands",
+						"end": "129M",
+						"#": "optional",
+						"flags": {
+							"#": "anything that parted understands",
+							"boot": "on"
+						}
+				
+					},
+
+					"#": "semi-required: either 'create' or 'existing' must be present",
+					"#": "below key is prepended with '#', since it's just an example!",
+					"#existing": {
+						"#": "required",
+						"device": "/dev/sda1",
+						"#": "optional, default=false",
+						"format": false
+					},
+
+					"#": "required: must be empty for swap",
+					"#": "ignored for msdos logical partitions",
+					"mountpoint": "/boot",
+					"#": "optional, default='' (one of: 'swap', 'luks', 'luks-gpg', '')",
+					"crypttype": "",
+					"#": "required",
+					"#": "ignored for msdos logical partitions",
+					"filesystem": "ext4-nojournal",
+					"#": "optional (default=false): maximise into free space",
+					"want_maximised": true
+				},
+				{
+					"create": {
+						"start": "129M",
+						"end": "1281M"
+					},
+					"mountpoint": "",
+					"filesystem": "swap",
+					"want_maximised": true
+				},
+				{
+					"create": {
+						"start": "1281M",
+						"end": "54G"
+					},
+					"mountpoint": "/",
+					"filesystem": "ext4",
+					"want_maximised": true
+				},
+				{
+					"existing": {
+						"device": "/dev/sda5",
+						"format": true
+					},
+					"mountpoint": "/mnt/logical1",
+					"filesystem": "ext4",
+					"want_maximised": true
+				},
+				{
+					"create": {
+						"partition-type": "logical",
+						"start": "60G",
+						"end": "64G"
+					},
+					"mountpoint": "/mnt/logical2",
+					"filesystem": "ext4",
+					"want_maximised": true
+				}
+
+			]
+		}
+	]
+}

--- a/config-samples/config.efi.gpt.json
+++ b/config-samples/config.efi.gpt.json
@@ -1,0 +1,111 @@
+{
+	"#": "optional (utc or localtime)",
+	"hwclock": "utc",
+
+	"#": "optional",
+	"timezone": "Europe/Zurich",
+
+	"#": "required",
+	"disks":[
+		{
+			"#": "required",
+			"device": "/dev/sda",
+
+			"#": "optional: will only be applied when set and different from current (msdos/gpt)",
+			"#": "requires wipe=true",
+			"partition-table": "gpt",
+
+			"#": "optional default=false",
+			"wipe": true,
+
+			"#": "required",
+			"partitions": [
+				{
+					"#": "semi-required: either 'create' or 'existing' must be present",
+					"create": {
+						"#": "optional (default=primary) for msdos: primary/extended/logical",
+						"#": "list extended before logical and only one extended per disk!",
+						"partition-type": "primary",
+
+						"#": "required",
+						"start": "1",
+
+						"#": "anything that parted understands",
+						"end": "551M",
+
+						"#": "optional, ignored for msdos",
+						"label": "boot",
+
+						"#": "optional",
+						"flags": {
+							"#": "anything that parted understands",
+							"boot": "on"
+						}
+					},
+
+					"#": "semi-required: either 'create' or 'existing' must be present",
+					"#": "below key is prepended with '#', since it's just an example!",
+					"#existing": {
+						"#": "required",
+						"device": "/dev/sda1",
+
+						"#": "optional, default=false",
+						"format": false
+					},
+
+					"#": "required: must be empty for swap",
+					"mountpoint": "/boot",
+
+					"#": "optional, default='' (one of: 'swap', 'luks', 'luks-gpg', '')",
+					"crypttype": "",
+
+					"#": "required",
+					"filesystem": "fat32",
+
+					"#": "optional (default=false): maximise into free space",
+					"want_maximised": true
+				},
+				{
+					"create": {
+						"start": "551M",
+						"end": "1575M",
+						"label": "swap"
+					},
+					"mountpoint": "",
+					"filesystem": "swap",
+					"want_maximised": true
+				},
+				{
+					"create": {
+						"start": "1575M",
+						"end": "54G",
+						"label": "root"
+					},
+					"mountpoint": "/",
+					"filesystem": "ext4",
+					"want_maximised": true
+				},
+				{
+					"create": {
+						"start": "54G",
+						"end": "60G",
+						"label": "test1"
+					},
+					"mountpoint": "/mnt/test1",
+					"filesystem": "ext4",
+					"want_maximised": true
+				},
+				{
+					"create": {
+						"start": "60G",
+						"end": "64G",
+						"label": "test2"
+					},
+					"mountpoint": "/mnt/test2",
+					"filesystem": "ext4",
+					"want_maximised": true
+				}
+			]
+		}
+	]
+}

--- a/config-samples/config.efi.msdos.json
+++ b/config-samples/config.efi.msdos.json
@@ -1,0 +1,116 @@
+{
+	"#": "optional (utc or localtime)",
+	"hwclock": "utc",
+
+	"#": "optional",
+	"timezone": "Europe/Zurich",
+
+	"#": "required",
+	"disks":[
+		{
+			"#": "required",
+			"device": "/dev/sda",
+
+			"#": "optional: will only be applied when set and different from current (msdos/gpt)",
+			"#": "requires wipe=true",
+			"partition-table": "msdos",
+
+			"#": "optional default=false",
+			"wipe": true,
+
+			"#": "required",
+			"partitions": [
+				{
+					"#": "semi-required: either 'create' or 'existing' must be present",
+					"create": {
+						"#": "optional (default=primary) for msdos: primary/extended/logical",
+						"#": "list extended before logical and only one extended per disk!",
+						"partition-type": "primary",
+
+						"#": "required",
+						"start": "1",
+
+						"#": "anything that parted understands",
+						"end": "551M",
+
+						"#": "optional",
+						"flags": {
+							"#": "anything that parted understands",
+							"boot": "on"
+						}
+					},
+
+					"#": "semi-required: either 'create' or 'existing' must be present",
+					"#": "below key is prepended with '#', since it's just an example!",
+					"#existing": {
+						"#": "required",
+						"device": "/dev/sda1",
+
+						"#": "optional, default=false",
+						"format": false
+					},
+
+					"#": "required: must be empty for swap",
+					"#": "ignored for msdos logical partitions",
+					"mountpoint": "/boot",
+
+					"#": "optional, default='' (one of: 'swap', 'luks', 'luks-gpg', '')",
+					"crypttype": "",
+
+					"#": "required",
+					"#": "ignored for msdos logical partitions",
+					"filesystem": "fat32",
+
+					"#": "optional (default=false): maximise into free space",
+					"want_maximised": true
+				},
+				{
+					"create": {
+						"start": "551M",
+						"end": "1575M"
+					},
+					"mountpoint": "",
+					"filesystem": "swap",
+					"want_maximised": true
+				},
+				{
+					"create": {
+						"start": "1575M",
+						"end": "54G"
+					},
+					"mountpoint": "/",
+					"filesystem": "ext4",
+					"want_maximised": true
+				},
+				{
+					"create": {
+						"partition-type": "extended",
+						"start": "54G",
+						"end": "64G"
+					},
+					"want_maximised": true
+				},
+				{
+					"create": {
+						"partition-type": "logical",
+						"start": "54G",
+						"end": "60G"
+					},
+					"mountpoint": "/mnt/test1",
+					"filesystem": "ext4",
+					"want_maximised": true
+				},
+				{
+					"create": {
+						"partition-type": "logical",
+						"start": "60G",
+						"end": "64G"
+					},
+					"mountpoint": "/mnt/test2",
+					"filesystem": "ext4",
+					"want_maximised": true
+				}
+			]
+		}
+	]
+}

--- a/sbin/pentoo-installer
+++ b/sbin/pentoo-installer
@@ -1,2 +1,2 @@
 #!/bin/bash
-/usr/share/pentoo-installer/pentoo-installer 2> /tmp/pentoo-installer.log
+/usr/share/pentoo-installer/pentoo-installer "${@}" 2> /tmp/pentoo-installer.log

--- a/share/pentoo-installer/bootloader_grub2
+++ b/share/pentoo-installer/bootloader_grub2
@@ -181,8 +181,10 @@ fi
 # set system editor (if not already defined)
 chroot_mount || exit $?
 EDITOR="$(geteditor)" || exit $?
-# let user edit grub menu file
-"${EDITOR}" "${GRUBCONFIG}" || exit $?
+# let user edit grub menu file (skipped for headless mode)
+if [ -z "${INSTALLER_HEADLESS:-}" ]; then
+	"${EDITOR}" "${GRUBCONFIG}" || exit $?
+fi
 
 #maybe move the stat check a LOT earlier?
 if [ -d /sys/firmware/efi ]; then

--- a/share/pentoo-installer/common.sh
+++ b/share/pentoo-installer/common.sh
@@ -463,7 +463,7 @@ show_dialog() {
 		elif [ -n "${_DEFAULTVALUE}" ]; then
 			_ANSWER="${_DEFAULTVALUE}"
 		elif [ "${_DIALOGBOX}" == '--calendar' ]; then
-			_ANSWER="$(date +'%m/%d/%Y')" || exit $?
+			_ANSWER="$(date +'%d/%m/%Y')" || exit $?
 		elif [ "${_DIALOGBOX}" == '--timebox' ]; then
 			_ANSWER="$(date +'%T')" || exit $?
 		# inputbox without default value, catch timeout

--- a/share/pentoo-installer/common.sh
+++ b/share/pentoo-installer/common.sh
@@ -198,7 +198,7 @@ get_yesno() {
 # arguments (required):
 #  _DISCLIST: List of involved discs or partitions
 #
-# exits: !=1 is an error
+# exits: !=0 is an error
 #
 mount_umountall() {
 	# check input
@@ -466,6 +466,12 @@ show_dialog() {
 			_ANSWER="$(date +'%m/%d/%Y')" || exit $?
 		elif [ "${_DIALOGBOX}" == '--timebox' ]; then
 			_ANSWER="$(date +'%T')" || exit $?
+		# inputbox without default value, catch timeout
+		elif [ "${_DIALOGBOX}" == '--inputbox' ]; then
+			if [ "${_ANSWER}" == $'\ntimeout' ]; then
+				echo "Error: input box in headless mode without default returned timeout" 1>&2
+				exit 1
+			fi
 		fi
 	# check if user clicked cancel or closed the box
 	elif [ "${_DIALOGRETURN}" -eq "1" ] || [ "${_DIALOGRETURN}" -eq "255" ]; then

--- a/share/pentoo-installer/common.sh
+++ b/share/pentoo-installer/common.sh
@@ -51,7 +51,7 @@ add_option_label() {
 # catch errors from sub-script/functions
 #
 # returns 0 when an error was given
-# otherwise returns 0
+# otherwise returns 1
 #
 # parameters (required):
 #  _FUNCNAME: name of calling function/script

--- a/share/pentoo-installer/common.sh
+++ b/share/pentoo-installer/common.sh
@@ -402,7 +402,7 @@ show_dialog() {
 		elif [ -n "${INSTALLER_HEADLESS:-}" ] && [ "${_ARGUMENTS[$_INDEX]}" == '--defaultno' ]; then
 			_ARGUMENTS[$_INDEX]='--nocancel'
 		elif [ "${_ARGUMENTS[$_INDEX]}" == '--inputbox' ]; then
-			if [ "$((${_INDEX}+4))" -le "${#_ARGUMENTS[@]}" ]; then
+			if [ "$((${_INDEX}+4))" -lt "${#_ARGUMENTS[@]}" ]; then
 				_DEFAULTVALUE="${_ARGUMENTS[$((_INDEX+4))]}" || exit $?
 			fi
 		elif [ "${_ARGUMENTS[$_INDEX]}" == '--menu' ]; then

--- a/share/pentoo-installer/configure_system
+++ b/share/pentoo-installer/configure_system
@@ -124,6 +124,7 @@ EOF
 check_num_args "$(basename $0)" 1 $# || exit $?
 CONFIG_LIST="${1}"
 EDITOR=
+DEFAULTITEM=
 MENU_ITEMS=
 NEWSELECTION=
 USERNAME=
@@ -151,8 +152,12 @@ MENU_ITEMS=("Editor"				"System Editor" \
 			"DONE"			"Return to Main Menu" )
 
 while true; do
+	# shortcut for headless mode
+	if [ -n "${INSTALLER_HEADLESS:-}" ]; then
+		DEFAULTITEM='--default-item DONE'
+	fi
 	# expand menu items array below
-	NEWSELECTION="$(show_dialog --menu "Configuration" \
+	NEWSELECTION="$(show_dialog ${DEFAULTITEM} --menu "Configuration" \
 		0 0 0 "${MENU_ITEMS[@]}")" || exit $?
 	# call subscript by selected item
 	case "${NEWSELECTION}" in

--- a/share/pentoo-installer/partition_autoconfig
+++ b/share/pentoo-installer/partition_autoconfig
@@ -1,0 +1,271 @@
+#!/bin/bash -x
+# This script is released under the GNU General Public License 3.0
+# Check the COPYING file included with this distribution
+
+# partition_autoconfig
+# apply preconfigured partition layout
+# parameters: none
+#
+# returns $ERROR_CANCEL=64 on user cancel
+# anything else is a real error
+# reason: show_dialog() needs a way to exit "Cancel"
+#
+# writes menus and noise to STDERR
+#
+# prints result to STDOUT
+
+# location of other scripts to source
+readonly SHAREDIR="$(dirname ${0})" || exit $?
+
+# source partitioning commons
+source "${SHAREDIR}"/partition_common.sh || exit $?
+
+#########################################
+## START: dialog functions/definitions ##
+
+# autoconfig_createpartition()
+# creates a partition
+#
+# returns 0 on success
+#
+# prints new JSON to STDOUT
+#
+# parameters (required):
+#  disk: json
+#  partnum: index in partition array
+#
+autoconfig_createpartition() {
+	# check input
+	check_num_args "${FUNCNAME}" 2 $# || return $?
+	local disk="${1}"
+	local partnum="${2}"
+	local diskblock="$(echo "${disk}" | jq -jr '."device"')" || return $?
+	local parttable="$(autoconfig_getpartitiontable "${disk}")" || return $?
+	local part="$(echo "${disk}" | jq -j ".partitions["${partnum}"]")" || return $?
+	local parttype="$(echo "$part" | jq -jr '.create."partition-type" // empty')" || return $?
+	local label="$(echo "$part" | jq -jr '.create.label // empty')" || return $?
+	local start="$(echo "$part" | jq -jr '.create.start')" || return $?
+	local end="$(echo "$part" | jq -jr '.create.end')" || return $?
+	local before="$(parted --script "${diskblock}" print | sed -e '/^$/d' -e '1,/^Number/d' | awk '{print $1}' | LC_ALL=C sort)" || return $?
+	local beforeDevices="$(blkid -o device | LC_ALL=C sort)" || return $?
+	local after=
+	local afterDevices=
+	local newDevice=
+	local index=
+	local flags=
+	local flagkey=
+	local flagvalue=
+	case "${parttable}" in
+		gpt)
+			parted -a optimal --script "${diskblock}" mkpart "${label}" ext4 $start $end || return $?
+			;;
+		msdos)
+			# default to primary
+			if [ -z "${parttype}" ]; then
+				parttype=primary
+			fi
+			case "${parttype}" in
+				primary|logical)
+					parted -a optimal --script "${diskblock}" mkpart "${parttype}" ext4 $start $end || return $?
+					;;
+				extended)
+					parted -a optimal --script "${diskblock}" mkpart "${parttype}" $start $end || return $?
+					;;
+				*)	echo "ERROR: Unknown partition type '${parttype}'." 1>&2
+					return 1 ;;
+			esac
+			;;
+		*) echo "ERROR: Unknown partition table '${parttable}'." 1>&2
+			return 1 ;;
+	esac
+	after="$(parted --script "${diskblock}" print | sed -e '/^$/d' -e '1,/^Number/d' | awk '{print $1}' | LC_ALL=C sort)" || return $?
+	afterDevices="$(blkid -o device | LC_ALL=C sort)" || return $?
+	index="$(join -v 2 <(echo "${before}") <(echo "${after}"))" || return $?
+	newDevice="$(join -v 2 <(echo "${beforeDevices}") <(echo "${afterDevices}"))" || return $?
+	echo "newDevice='${newDevice}'" 1>&2 || return $?
+	# flags is set
+	if echo "${part}" | jq -e ".create.flags" 1>/dev/null; then
+		flags="$(echo "${part}" | jq -j ".create.flags")" || return $?
+		for flagkey in $(echo "${flags}" | jq -r 'keys | .[]'); do
+			flagvalue="$(echo "${part}" | jq -j ".flags.${flagkey}")" || return $?
+			parted --script "${diskblock}" set "${index}" "${flagkey}"  || return $?
+		done
+	fi
+	# modify json to return new object
+	# add existing object
+	disk="$(echo "${disk}" | jq -e ".partitions[${partnum}].existing = {\"device\":\"${newDevice}\"}")"
+	# remove create object
+	disk="$(echo "${disk}" | jq -e "del(.partitions[${partnum}].create)")"
+	if [ "${parttype}" == 'extended' ]; then
+		# add extended=true
+		disk="$(echo "${disk}" | jq -e ".partitions[${partnum}].existing.extended = true")"
+	else
+		# set format = true
+		disk="$(echo "${disk}" | jq -e ".partitions[${partnum}].existing.format = true")"
+	fi
+	# print new json
+	echo "${disk}"
+	return 0
+}
+
+# autoconfig_printpartition()
+# prints partition
+#
+# returns 0 on success
+#
+# parameters (required):
+#  disk: json
+#  partnum: index in partition array
+#
+autoconfig_printpartition() {
+	# check input
+	check_num_args "${FUNCNAME}" 2 $# || return $?
+	local disk="${1}"
+	local partnum="${2}"
+	local part="$(echo "${disk}" | jq -j ".partitions["${partnum}"]")" || return $?
+	# don't print/use msdos extended partitions
+	if !(echo "${part}" | jq -e ".existing.extended" 1>/dev/null); then
+		local partblock="$(echo "${part}" | jq -jr '.existing.device')" || return $?
+		local mountpoint="$(echo "${part}" | jq -jr '."mountpoint"')" || return $?
+		local filesystem="$(echo "${part}" | jq -jr '.filesystem')" || return $?
+		local crypttype="$(echo "${part}" | jq -jr '.crypttype // empty')" || return $?
+		local format=0
+		# format is set
+		if echo "${part}" | jq -e ".existing.format" 1>/dev/null; then
+			format=1
+		fi
+		# validate
+		"${SHAREDIR}"/FSspec create "${partblock}" "${mountpoint}" "${filesystem}" "${crypttype}" "${format}" 1>/dev/null || return $?
+		local fsspec="$("${SHAREDIR}"/FSspec create "${partblock}" "${mountpoint}" "${filesystem}" "${crypttype}" "${format}")" || return $?
+		echo -n "${fsspec}"
+	fi
+}
+
+# autoconfig_getpartitionindex()
+# prints partition index
+#
+# returns 0 on success
+#
+# parameters (required):
+#  disk: json
+#  partnum: index in partition array
+#  
+#
+autoconfig_getpartitionindex() {
+	# check input
+	check_num_args "${FUNCNAME}" 2 $# || return $?
+	local disk="${1}"
+	local partnum="${2}"
+	local diskblock="$(echo "${disk}" | jq -jr '."device"')" || return $?
+	local parttable="$(autoconfig_getpartitiontable "${disk}")" || return $?
+	local part="$(echo "${disk}" | jq -j ".partitions["${partnum}"]")" || return $?
+	local partblock="$(echo "${part}" | jq -jr '."device"')" || return $?
+	local partshort="$(basename "${partblock}")" || return $?
+	local maxpart="$(lsblk -J /dev/sda | jq -j '..|.children? // empty | length')" || return $?
+	local partnum
+	local partname=
+	for (( partnum=0; partnum<${maxpart}; partnum++ )); do
+		partname="$(lsblk -J /dev/sda | jq -jr "..|.children? // empty | .[$partnum].name")" || return $?
+		if [ "${partname}" == "${partshort}" ]; then
+			echo -n "$((partnum + 1))"; return  $?
+		fi
+	done
+	return 1
+}
+
+# autoconfig_getpartitiontable()
+# prints partition table
+# either from config file or current
+#
+# returns 0 on success
+#
+# parameters (required):
+#  disk: json
+#
+autoconfig_getpartitiontable() {
+	# check input
+	check_num_args "${FUNCNAME}" 1 $# || return $?
+	local disk="${1}"
+	# partition table is set
+	if echo "${disk}" | jq -e '."partition-table"' 1>/dev/null; then
+		echo "${disk}" | jq -jr '."partition-table"'; return $?
+	else
+		parted --script "${disk}" print | sed -En 's#^Partition Table: (.*)#\1#p'; return $?
+	fi
+}
+
+## END: dialog functions/definitions ##
+#######################################
+
+#####################
+## begin execution ##
+
+# remove comments
+CONF_FULL="$(cat "${INSTALLER_CONFIGFILE}" | jq 'del(..|.["#"]?)')" || exit $?
+# get array of disks with partitions
+CONF_DISKS="$(echo "${CONF_FULL}" | jq '..|.disks? // empty')" || exit $?
+
+LEN_DISKS="$(echo "${CONF_DISKS}" | jq -j 'length')" || exit $?
+
+# loop disks
+DISKNUM=
+PARTNUM=
+for (( DISKNUM=0; DISKNUM<${LEN_DISKS}; DISKNUM++ )); do
+	DISK="$(echo "${CONF_DISKS}" | jq ".[${DISKNUM}]")" || exit $?
+	DISK_BLOCK="$(echo "${DISK}" | jq -jr '."device"')" || exit $?
+	# wipe is set
+	if echo "${DISK}" | jq -e '.wipe' 1>/dev/null; then
+		PARTTABLE="$(autoconfig_getpartitiontable "${DISK}")" || exit $?
+		# set partition table
+		parted --script "${DISK_BLOCK}" mklabel "${PARTTABLE}" || exit $?
+	fi
+	# loop partitions to create them
+	LEN_PARTS="$(echo "${DISK}" | jq -j '.partitions | length')" || exit $?
+	for (( PARTNUM=0; PARTNUM<${LEN_PARTS}; PARTNUM++ )); do
+		CREATEPART=1
+		USEPART=1
+		# check if create is set
+		if echo "${DISK}" | jq -e ".partitions[${PARTNUM}].create" 1>/dev/null; then
+			CREATEPART=0
+		fi
+		# check if existing is set
+		if echo "${DISK}" | jq -e ".partitions[${PARTNUM}].existing" 1>/dev/null; then
+			USEPART=0
+		fi
+		# safety check
+		if [ $((CREATEPART+USEPART)) -ne 1 ]; then
+			echo "ERROR: Either 'create' or 'existing' must be used, not both." 1>&2
+			exit 1
+		fi
+		if [ $CREATEPART -eq 0 ]; then
+			DISK="$(autoconfig_createpartition "${DISK}" "${PARTNUM}")" || exit $?
+			# replace in parent json
+			CONF_DISKS="$(echo "${CONF_DISKS}" | jq ".[${DISKNUM}] = ${DISK}")" || exit $?
+		fi
+	done
+	# loop partitions to maximise them
+	for (( PARTNUM=0; PARTNUM<${LEN_PARTS}; PARTNUM++ )); do
+		# want_maximised is set
+		if echo "${DISK}" | jq -e ".partitions[${PARTNUM}].want_maximised" 1>/dev/null; then
+			PARTINDEX="$(autoconfig_getpartitionindex "${DISK}" "${PARTNUM}")"
+			if growpart -N "${DISK_BLOCK}" "${PARTINDEX}" 1>&2; then
+				growpart "${DISK_BLOCK}" "${PARTINDEX}" 1>&2 || exit $?
+			fi
+		fi
+	done
+done
+
+# print output
+# loop disks
+for (( DISKNUM=0; DISKNUM<${LEN_DISKS}; DISKNUM++ )); do
+	DISK="$(echo "${CONF_DISKS}" | jq ".[${DISKNUM}]")" || exit $?
+	# loop partitions
+	LEN_PARTS="$(echo "${DISK}" | jq -j '.partitions | length')" || exit $?
+	for (( PARTNUM=0; PARTNUM<${LEN_PARTS}; PARTNUM++ )); do
+		if [ $DISKNUM -gt 0 ] || [ $PARTNUM -gt 0 ];then
+			echo -n ' '
+		fi
+		autoconfig_printpartition "${DISK}" "${PARTNUM}" || exit $?
+	done
+done
+echo

--- a/share/pentoo-installer/partition_mainmenu
+++ b/share/pentoo-installer/partition_mainmenu
@@ -103,9 +103,14 @@ while true; do
 	# handle errors from sub-script/functions using a common utility function
 	if ! catch_menuerror "$(basename $0)" "${NEWSELECTION}" "${RETSUB}"; then
 		# everything ok, increase selection for next menu item
-		# jump from auto-prepare directly to mountpoints
 		if [ "${SELECTION}" -eq 0 ]; then
-			SELECTION=2
+			if [ -n "${INSTALLER_HEADLESS:-}" ]; then
+				# jump from auto-prepare directly to create-FS and exit (headless mode)
+				SELECTION=3
+			else
+				# jump from auto-prepare directly to mountpoints
+				SELECTION=2
+			fi
 		else
 			SELECTION="$((NEWSELECTION+1))" || exit $?
 		fi

--- a/share/pentoo-installer/partition_mainmenu
+++ b/share/pentoo-installer/partition_mainmenu
@@ -31,6 +31,12 @@ MAXSELECTION="0"
 CONFIG_LIST=
 CONFIG_LIST_NEW=
 
+# run from config-file
+if [ -n "${INSTALLER_CONFIGFILE:-}" ]; then
+	CONFIG_LIST="$("${SHAREDIR}"/partition_autoconfig)" || exit $?
+	SELECTION='3'
+fi
+
 while true; do
 	# define menu items
 	MENU_ITEMS=("0" "Guided Partitioning (erases the ENTIRE hard drive)" \

--- a/share/pentoo-installer/pentoo-installer
+++ b/share/pentoo-installer/pentoo-installer
@@ -138,17 +138,29 @@ checkvm() {
 
 # INSTALLER_HEADLESS: emtpy=false
 export INSTALLER_HEADLESS=
+export INSTALLER_CONFIGFILE=
 
 # check passed arguments
 while [[ $# -gt 0 ]]; do
+  # these options require params
+  case "${1}" in
+    --config-file)
+	  if [ $# -lt 2 ] || [ "${2:0:2}" == '--' ]; then
+		  show_dialog --msgbox "ERROR: Option '${1}' requires a parameter. Aborting with  error." 0 0
+		  exit 1
+	  fi
+  esac
+  # process arguments
   case "${1}" in
     --headless)
       export INSTALLER_HEADLESS=1
-      shift
-      ;;
-    *)    # unknown option
+      shift ;;
+    --config-file)
+      export INSTALLER_CONFIGFILE="${2}"
+      shift; shift ;;
+    *) # unknown option
       show_dialog --msgbox "ERROR: Unknown option '${1}'. Aborting with  error." 0 0
-      printf "ERROR: Unknown option '${1}'. Aborting with error." 1>&2 && exit 1
+      exit 1
       ;;
   esac
 done

--- a/share/pentoo-installer/pentoo-installer
+++ b/share/pentoo-installer/pentoo-installer
@@ -136,6 +136,23 @@ checkvm() {
 #####################
 ## begin execution ##
 
+# INSTALLER_HEADLESS: emtpy=false
+export INSTALLER_HEADLESS=
+
+# check passed arguments
+while [[ $# -gt 0 ]]; do
+  case "${1}" in
+    --headless)
+      export INSTALLER_HEADLESS=1
+      shift
+      ;;
+    *)    # unknown option
+      show_dialog --msgbox "ERROR: Unknown option '${1}'. Aborting with  error." 0 0
+      printf "ERROR: Unknown option '${1}'. Aborting with error." 1>&2 && exit 1
+      ;;
+  esac
+done
+
 # display welcome txt depending on used dialog
 WHICHDIALOG="$(get_dialog)"
 

--- a/share/pentoo-installer/settzclock
+++ b/share/pentoo-installer/settzclock
@@ -46,7 +46,7 @@ sed -Ei 's#^clock="[^"]*"$#clock="'"${HARDWARECLOCK:0:5}"'"#' /etc/conf.d/hwcloc
 # the sed commands make the few necessary changes
 cp /usr/bin/tzselect /tmp/tzselect.patched \
 	&& sed -i 's#^\t+#\t*#' /tmp/tzselect.patched \
-	&& patch --silent /tmp/tzselect.patched -i "${SHAREDIR}"/timezone-data-2015e-dialog.patch
+	&& patch --silent /tmp/tzselect.patched -i "${SHAREDIR}"/timezone-data-2018d-dialog.patch
 	TIMEZONE="$(SHOWDIALOG="${SHAREDIR}"/tzselect_dialog /tmp/tzselect.patched)" \
 	&& rm /tmp/tzselect.patched \
 	|| exit $?

--- a/share/pentoo-installer/settzclock
+++ b/share/pentoo-installer/settzclock
@@ -55,6 +55,7 @@ cp /usr/bin/tzselect /tmp/tzselect.patched \
 if [ "${TIMEZONE}" != "" -a -e "/usr/share/zoneinfo/${TIMEZONE}" ]; then
 	echo "setting timezone to: ${TIMEZONE}" 1>&2
 	echo "${TIMEZONE}" > /etc/timezone
+	emerge --config sys-libs/timezone-data || exit $?
 fi
 
 # display and ask to set date/time

--- a/share/pentoo-installer/settzclock
+++ b/share/pentoo-installer/settzclock
@@ -26,8 +26,22 @@ readonly SHAREDIR="$(dirname ${0})" || exit $?
 # source common variables, functions and error handling
 source "${SHAREDIR}"/common.sh || exit $?
 
+HWCLOCK_DEFAULT=utc
+TIMEZONE_DEFAULT=
+if [ -n "${INSTALLER_CONFIGFILE}" ]; then
+	# remove comments
+	CONF_FULL="$(cat "${INSTALLER_CONFIGFILE}" | jq 'del(..|.["#"]?)')" || exit $?
+	# check if hwclock is set
+	if echo "${CONF_FULL}" | jq -e ".hwclock" 1>/dev/null; then
+		HWCLOCK_DEFAULT="$(echo "${CONF_FULL}" | jq -re ".hwclock")" || exit $?
+	fi
+	# check if timezone is set
+	if echo "${CONF_FULL}" | jq -e ".timezone" 1>/dev/null; then
+		TIMEZONE_DEFAULT="$(echo "${CONF_FULL}" | jq -re ".timezone")" || exit $?
+	fi
+fi
 # utc or local?
-HARDWARECLOCK="$(show_dialog --menu "Is your hardware clock in UTC or time?" 0 0 2 \
+HARDWARECLOCK="$(show_dialog --default-item "${HWCLOCK_DEFAULT}" --menu "Is your hardware clock in UTC or time?" 0 0 2 \
 	"utc" "UTC time" \
 	"localtime" "local time")" \
 	|| exit $?
@@ -46,10 +60,16 @@ sed -Ei 's#^clock="[^"]*"$#clock="'"${HARDWARECLOCK:0:5}"'"#' /etc/conf.d/hwcloc
 # the sed commands make the few necessary changes
 cp /usr/bin/tzselect /tmp/tzselect.patched \
 	&& sed -i 's#^\t+#\t*#' /tmp/tzselect.patched \
-	&& patch --silent /tmp/tzselect.patched -i "${SHAREDIR}"/timezone-data-2018d-dialog.patch
-	TIMEZONE="$(SHOWDIALOG="${SHAREDIR}"/tzselect_dialog /tmp/tzselect.patched)" \
+	&& patch --silent /tmp/tzselect.patched -i "${SHAREDIR}"/timezone-data-2018d-dialog.patch \
+	|| exit $?
+TIMEZONE="$(SHOWDIALOG="${SHAREDIR}"/tzselect_dialog /tmp/tzselect.patched)" \
 	&& rm /tmp/tzselect.patched \
 	|| exit $?
+
+if [ -n "${TIMEZONE_DEFAULT}" ]; then
+	echo "Overriding timezone with value from config file!" 1>&2
+	TIMEZONE="${TIMEZONE_DEFAULT}"
+fi
 
 # this will be copied to chroot later
 if [ "${TIMEZONE}" != "" -a -e "/usr/share/zoneinfo/${TIMEZONE}" ]; then

--- a/share/pentoo-installer/timezone-data-2018d-dialog.patch
+++ b/share/pentoo-installer/timezone-data-2018d-dialog.patch
@@ -1,8 +1,8 @@
 based on original work by wuodan here:
-https://github.com/Wuodan/tz/commit/5297b9ca06f79c334b9492713ce388b590e436e3
+https://github.com/Wuodan/tz
 
---- tzselect.patched	2015-09-19 23:23:37.357786123 -0400
-+++ tzselect.patched2	2015-09-19 23:49:50.395684504 -0400
+--- tzselect.patched
++++ tzselect.patched
 @@ -36,6 +36,7 @@
  # Specify default values for environment variables if they are unset.
  : ${AWK=awk}
@@ -127,35 +127,39 @@ https://github.com/Wuodan/tz/commit/5297b9ca06f79c334b9492713ce388b590e436e3
  		"coord - I want to use geographical coordinates." \
 -		"TZ - I want to specify the time zone using the Posix TZ format."
 -	    continent=$select_result
-+		"TZ - I want to specify the time zone using the Posix TZ format."` || exit $?
++		"TZ - I want to specify the timezone using the Posix TZ format."` || exit $?
  	    case $continent in
  	    Americas) continent=America;;
  	    *" "*) continent=`expr "$continent" : '\''\([^ ]*\)'\''`
-@@ -340,11 +382,9 @@
+@@ -340,13 +382,10 @@
  	TZ)
  		# Ask the user for a Posix TZ string.  Check that it conforms.
  		while
 -			echo >&2 'Please enter the desired value' \
 -				'of the TZ environment variable.'
--			echo >&2 'For example, GST-10 is a zone named GST' \
--				'that is 10 hours ahead (east) of UTC.'
+-			echo >&2 'For example, AEST-10 is a zone named AEST' \
+-				'that is 10 hours'
+-			echo >&2 'ahead (east) of Greenwich,' \
+-				'with no daylight saving time.'
 -			read TZ
 +			TZ=`"${SHOWDIALOG}" inputbox \
 +				'Please enter the desired value of the TZ environment variable.
-+For example, GST-10 is a zone named GST that is 10 hours ahead (east) of UTC.'` || exit $?
++For example, AEST-10 is abbreviated AEST and is 10 hours
++ahead (east) of Greenwich, with no daylight saving time.'` || exit $?
  			$AWK -v TZ="$TZ" 'BEGIN {
- 				tzname = "[^-+,0-9][^-+,0-9][^-+,0-9]+"
- 				time = "[0-2]?[0-9](:[0-5][0-9](:[0-5][0-9])?)?"
-@@ -357,7 +397,7 @@
+ 				tzname = "(<[[:alnum:]+-]{3,}>|[[:alpha:]]{3,})"
+ 				time = "(2[0-4]|[0-1]?[0-9])" \
+@@ -362,7 +401,8 @@
  				exit 0
  			}'
  		do
 -		    say >&2 "'$TZ' is not a conforming Posix time zone string."
-+			"${SHOWDIALOG}" msgbox "'$TZ' is not a conforming Posix time zone string."
++			"${SHOWDIALOG}" msgbox \
++				"'$TZ' is not a conforming Posix time zone string."
  		done
  		TZ_for_date=$TZ;;
  	*)
-@@ -365,12 +405,10 @@
+@@ -370,12 +410,10 @@
  		coord)
  		    case $coord in
  		    '')
@@ -172,7 +176,7 @@ https://github.com/Wuodan/tz/commit/5297b9ca06f79c334b9492713ce388b590e436e3
  		    esac
  		    distance_table=`$AWK \
  			    -v coord="$coord" \
-@@ -383,12 +421,10 @@
+@@ -388,13 +426,11 @@
  		      BEGIN { FS = "\t" }
  		      { print $NF }
  		    '`
@@ -182,14 +186,16 @@ https://github.com/Wuodan/tz/commit/5297b9ca06f79c334b9492713ce388b590e436e3
 -			    "of distance from $coord".
 -		    doselect $regions
 -		    region=$select_result
+-		    TZ=`say "$distance_table" | $AWK -v region="$region" '
 +		    region=`"${SHOWDIALOG}" menu \
-+		    "Please select one of the following time zone regions,
++		      "Please select one of the following timezones,
 +listed roughly in increasing order of distance from $coord." \
-+		    $regions` || exit $?
- 		    TZ=`say "$distance_table" | $AWK -v region="$region" '
++		      $regions` || exit $?
++		    TZ=`echo "$distance_table" | $AWK -v region="$region" '
  		      BEGIN { FS="\t" }
  		      $NF == region { print $4 }
-@@ -425,10 +461,9 @@
+ 		    '`
+@@ -430,10 +466,9 @@
  		# If there's more than one country, ask the user which one.
  		case $countries in
  		*"$newline"*)
@@ -203,7 +209,7 @@ https://github.com/Wuodan/tz/commit/5297b9ca06f79c334b9492713ce388b590e436e3
  		*)
  			country=$countries
  		esac
-@@ -457,10 +492,9 @@
+@@ -462,10 +497,9 @@
  		# If there's more than one region, ask the user which one.
  		case $regions in
  		*"$newline"*)
@@ -212,23 +218,23 @@ https://github.com/Wuodan/tz/commit/5297b9ca06f79c334b9492713ce388b590e436e3
 -			doselect $regions
 -			region=$select_result;;
 +			region=`"${SHOWDIALOG}" menu \
-+				'Please select one of the following time zone regions.' \
++				'Please select one of the following timezones.' \
 +				$regions` || exit $?;;
  		*)
  			region=$regions
  		esac
-@@ -518,22 +552,24 @@
+@@ -522,23 +556,24 @@
+ 
  
  	# Output TZ info and ask the user to confirm.
- 
--	echo >&2 ""
--	echo >&2 "The following information has been given:"
--	echo >&2 ""
 +	infomsg='
 +The following information has been given:
 +
 +'
-+
+ 
+-	echo >&2 ""
+-	echo >&2 "The following information has been given:"
+-	echo >&2 ""
  	case $country%$region%$coord in
 -	?*%?*%)	say >&2 "	$country$newline	$region";;
 -	?*%%)	say >&2 "	$country";;
@@ -239,7 +245,7 @@ https://github.com/Wuodan/tz/commit/5297b9ca06f79c334b9492713ce388b590e436e3
 +	?*%%)   infomsg="${infomsg}     $country";;
 +	%?*%?*) infomsg="${infomsg}     coord $coord$newline    $region";;
 +	%%?*)   infomsg="${infomsg}     coord $coord";;
-+	*)              infomsg="${infomsg}     TZ='$TZ'"
++	*)      infomsg="${infomsg}     TZ='$TZ'"
  	esac
 -	say >&2 ""
 -	say >&2 "Therefore TZ='$TZ' will be used.$extra_info"


### PR DESCRIPTION
Testing ISOs and the installer takes a lot of time and manual effort ... until now!

**Demo:**

> emerge -u app-emulation/virtualbox app-emulation/packer app-emulation/vagrant
> git clone https://github.com/Wuodan/pentoo-packer.git
> cd pentoo-packer
> ./pentoo-packer.sh [url-to-iso]
> ./pentoo-packer.sh http://mirror.switch.ch/ftp/mirror/pentoo/Beta/Pentoo_amd64_hardened/pentoo-amd64-hardened-2018.0_RC8_p20181023.iso
> vagrant up

This does everything:

1. Download ISO
1. Boot from ISO
1. Update
1. Install Pentoo (headless, no user interaction)
1. Boot from disk to installed Pentoo

If anything goes wrong, the build stops and one can inspect the running vm.
Logs are in ./packer.log.

**Parallel build several different VMs**
This demo config builds 2 different VMs in parallel. CPU and RAM are different, disk layout for the installer is from one of the sample config files in this PR: https://github.com/Wuodan/pentoo-installer/blob/config-file/config-samples/config.bios.msdos.json

**JSON config files**
This enables the installer to use a json config file for timezone, disk layout, etc. See the samples.
Fix for #34

(We could later replace the installers el-cheapo config-format with json.)

**Ebuild**
This requires minor changes to the ebuild: json-reader, sample config-files.
See https://github.com/Wuodan/gentoo-overlay/blob/master/pentoo/pentoo-installer/pentoo-installer-20180805.ebuild

**Todo**
Unrelated to this commit - this demo only uses bios not uefi and I was not yet able to get vagrant-ssh to work, which would enable auto-things after the VM reboots.