### PR TITLE
Add new patch for timezone-data-2018g

### DIFF
--- a/share/pentoo-installer/settzclock
+++ b/share/pentoo-installer/settzclock
@@ -58,9 +58,13 @@ sed -Ei 's#^clock="[^"]*"$#clock="'"${HARDWARECLOCK:0:5}"'"#' /etc/conf.d/hwcloc
 # which does essentially the same but uses dialog/Xdialog
 # see https://github.com/Wuodan/tz/commit/5297b9ca06f79c334b9492713ce388b590e436e3
 # the sed commands make the few necessary changes
+PATCHVER=2018g
+if [[ "$(equery --quiet list --format='$version' timezone-data)" < "${PATCHVER}" ]]; then
+	PATCHVER=2018d
+fi
 cp /usr/bin/tzselect /tmp/tzselect.patched \
 	&& sed -i 's#^\t+#\t*#' /tmp/tzselect.patched \
-	&& patch --silent /tmp/tzselect.patched -i "${SHAREDIR}"/timezone-data-2018d-dialog.patch \
+	&& patch --silent /tmp/tzselect.patched -i "${SHAREDIR}"/timezone-data-"${PATCHVER}"-dialog.patch \
 	|| exit $?
 TIMEZONE="$(SHOWDIALOG="${SHAREDIR}"/tzselect_dialog /tmp/tzselect.patched)" \
 	&& rm /tmp/tzselect.patched \

--- a/share/pentoo-installer/timezone-data-2018g-dialog.patch
+++ b/share/pentoo-installer/timezone-data-2018g-dialog.patch
@@ -1,0 +1,261 @@
+based on original work by wuodan here:
+https://github.com/Wuodan/tz
+
+--- tzselect.patched
++++ tzselect.patched
+@@ -35,6 +35,7 @@
+ # Specify default values for environment variables if they are unset.
+ : ${AWK=awk}
+ : ${TZDIR=/usr/share/zoneinfo}
++: ${SHOWDIALOG=showdialog}
+ 
+ # Output one argument as-is to standard output.
+ # Safer than 'echo', which can mishandle '\' or leading '-'.
+@@ -78,9 +79,10 @@
+ Report bugs to $REPORT_BUGS_TO."
+ 
+ # Ask the user to select from the function's arguments,
+-# and assign the selected argument to the variable 'select_result'.
++# and print selected argument
+ # Exit on EOF or I/O error.  Use the shell's 'select' builtin if available,
+ # falling back on a less-nice but portable substitute otherwise.
++# First argument is the message preceeding the selection
+ if
+   case $BASH_VERSION in
+   ?*) : ;;
+@@ -93,11 +95,15 @@
+   # even though it is never executed.
+   eval '
+     doselect() {
++      # print message first
++      echo >&2 "${1}"
++      shift
+       select select_result
+       do
+ 	case $select_result in
+ 	"") echo >&2 "Please enter a number in range." ;;
+-	?*) break
++	# print result
++	?*) echo -n "${select_result}"; break
+ 	esac
+       done || exit
+     }
+@@ -112,6 +118,9 @@
+   '
+ else
+   doselect() {
++    # print message first
++    echo >&2 "${1}"
++    shift
+     # Field width of the prompt numbers.
+     select_width=`expr $# : '.*'`
+ 
+@@ -133,6 +142,8 @@
+ 	if test 1 -le $select_i && test $select_i -le $#; then
+ 	  shift `expr $select_i - 1`
+ 	  select_result=$1
++	  # print result
++	  echo -n "${select_result}"
+ 	  break
+ 	fi
+ 	echo >&2 'Please enter a number in range.'
+@@ -145,6 +156,38 @@
+   }
+ fi
+ 
++# showdialog()
++# All normal user input/output goes through this function
++#
++# The user dialog of this script can be altered by setting
++# the SHOWDIALOG variable as in:
++# SHOWDIALOG=$PWD/tzselect_dialog tzselect
++# where 'tzselect_dialog' imitates this function
++#
++# Arguments:
++#  Type: one of: menu, yesno, msgbox, inputbox
++#  Message: text to display
++#  Options: menu-options, only for types menu and yesno
++#
++showdialog() {
++	# action depends on first argument
++	case "${1}" in
++		menu|yesno)
++			shift
++			doselect "${@}"
++			return $? ;;
++		msgbox)
++			echo >&2 "${2}"
++			return 0 ;;
++		inputbox)
++			echo >&2 "${2}"
++			read INPUTBOX
++			echo -n "${INPUTBOX}"
++			return 0 ;;
++	esac
++	return 1
++}
++
+ while getopts c:n:t:-: opt
+ do
+     case $opt$OPTARG in
+@@ -290,8 +333,7 @@
+ # Begin the main loop.  We come back here if the user wants to retry.
+ while
+ 
+-	echo >&2 'Please identify a location' \
+-		'so that time zone rules can be set correctly.'
++	dialogtext='Please identify a location so that time zone rules can be set correctly.'
+ 
+ 	continent=
+ 	country=
+@@ -304,7 +346,8 @@
+ 
+ 	# Ask the user for continent or ocean.
+ 
+-	echo >&2 'Please select a continent, ocean, "coord", or "TZ".'
++	dialogtext="${dialogtext}
++Please select a continent, ocean, \"coord\", or \"TZ\"."
+ 
+         quoted_continents=`
+ 	  $AWK '
+@@ -324,10 +367,9 @@
+ 	`
+ 
+ 	eval '
+-	    doselect '"$quoted_continents"' \
++		continent=`"${SHOWDIALOG}" menu '\'"${dialogtext}"\'' '"$quoted_continents"' \
+ 		"coord - I want to use geographical coordinates." \
+-		"TZ - I want to specify the timezone using the Posix TZ format."
+-	    continent=$select_result
++		"TZ - I want to specify the timezone using the Posix TZ format."` || exit $?
+ 	    case $continent in
+ 	    Americas) continent=America;;
+ 	    *" "*) continent=`expr "$continent" : '\''\([^ ]*\)'\''`
+@@ -339,13 +381,10 @@
+ 	TZ)
+ 		# Ask the user for a Posix TZ string.  Check that it conforms.
+ 		while
+-			echo >&2 'Please enter the desired value' \
+-				'of the TZ environment variable.'
+-			echo >&2 'For example, AEST-10 is abbreviated' \
+-				'AEST and is 10 hours'
+-			echo >&2 'ahead (east) of Greenwich,' \
+-				'with no daylight saving time.'
+-			read TZ
++			TZ=`"${SHOWDIALOG}" inputbox \
++				'Please enter the desired value of the TZ environment variable.
++For example, AEST-10 is abbreviated AEST and is 10 hours
++ahead (east) of Greenwich, with no daylight saving time.'` || exit $?
+ 			$AWK -v TZ="$TZ" 'BEGIN {
+ 				tzname = "(<[[:alnum:]+-]{3,}>|[[:alpha:]]{3,})"
+ 				time = "(2[0-4]|[0-1]?[0-9])" \
+@@ -361,7 +400,8 @@
+ 				exit 0
+ 			}'
+ 		do
+-		    say >&2 "'$TZ' is not a conforming Posix timezone string."
++			"${SHOWDIALOG}" msgbox \
++				"'$TZ' is not a conforming Posix time zone string."
+ 		done
+ 		TZ_for_date=$TZ;;
+ 	*)
+@@ -369,12 +409,10 @@
+ 		coord)
+ 		    case $coord in
+ 		    '')
+-			echo >&2 'Please enter coordinates' \
+-				'in ISO 6709 notation.'
+-			echo >&2 'For example, +4042-07403 stands for'
+-			echo >&2 '40 degrees 42 minutes north,' \
+-				'74 degrees 3 minutes west.'
+-			read coord;;
++			coord=`"${SHOWDIALOG}" inputbox \
++				'Please enter coordinates in ISO 6709 notation.
++For example, +4042-07403 stands for
++40 degrees 42 minutes north, 74 degrees 3 minutes west.'` || exit $?
+ 		    esac
+ 		    distance_table=`$AWK \
+ 			    -v coord="$coord" \
+@@ -387,12 +425,11 @@
+ 		      BEGIN { FS = "\t" }
+ 		      { print $NF }
+ 		    '`
+-		    echo >&2 'Please select one of the following timezones,' \
+-		    echo >&2 'listed roughly in increasing order' \
+-			    "of distance from $coord".
+-		    doselect $regions
+-		    region=$select_result
+-		    TZ=`say "$distance_table" | $AWK -v region="$region" '
++		    region=`"${SHOWDIALOG}" menu \
++		      "Please select one of the following timezones,
++listed roughly in increasing order of distance from $coord." \
++		      $regions` || exit $?
++		    TZ=`echo "$distance_table" | $AWK -v region="$region" '
+ 		      BEGIN { FS="\t" }
+ 		      $NF == region { print $4 }
+ 		    '`
+@@ -428,10 +465,9 @@
+ 		# If there's more than one country, ask the user which one.
+ 		case $countries in
+ 		*"$newline"*)
+-			echo >&2 'Please select a country' \
+-				'whose clocks agree with yours.'
+-			doselect $countries
+-			country=$select_result;;
++			country=`"${SHOWDIALOG}" menu \
++				'Please select a country whose clocks agree with yours.' \
++				$countries` || exit $?;;
+ 		*)
+ 			country=$countries
+ 		esac
+@@ -460,9 +496,9 @@
+ 		# If there's more than one region, ask the user which one.
+ 		case $regions in
+ 		*"$newline"*)
+-			echo >&2 'Please select one of the following timezones.'
+-			doselect $regions
+-			region=$select_result;;
++			region=`"${SHOWDIALOG}" menu \
++				'Please select one of the following timezones.' \
++				$regions` || exit $?;;
+ 		*)
+ 			region=$regions
+ 		esac
+@@ -519,23 +555,24 @@
+ 
+ 
+ 	# Output TZ info and ask the user to confirm.
++	infomsg='
++The following information has been given:
++
++'
+ 
+-	echo >&2 ""
+-	echo >&2 "The following information has been given:"
+-	echo >&2 ""
+ 	case $country%$region%$coord in
+-	?*%?*%)	say >&2 "	$country$newline	$region";;
+-	?*%%)	say >&2 "	$country";;
+-	%?*%?*) say >&2 "	coord $coord$newline	$region";;
+-	%%?*)	say >&2 "	coord $coord";;
+-	*)	say >&2 "	TZ='$TZ'"
++	?*%?*%) infomsg="${infomsg}     $country$newline        $region";;
++	?*%%)   infomsg="${infomsg}     $country";;
++	%?*%?*) infomsg="${infomsg}     coord $coord$newline    $region";;
++	%%?*)   infomsg="${infomsg}     coord $coord";;
++	*)      infomsg="${infomsg}     TZ='$TZ'"
+ 	esac
+-	say >&2 ""
+-	say >&2 "Therefore TZ='$TZ' will be used.$extra_info"
+-	say >&2 "Is the above information OK?"
++	infomsg="${infomsg}
++
++Therefore TZ='$TZ' will be used.$extra_info
++Is the above information OK?"
+ 
+-	doselect Yes No
+-	ok=$select_result
++	ok=`"${SHOWDIALOG}" yesno "${infomsg}" Yes No` || exit $?
+ 	case $ok in
+ 	Yes) break
+ 	esac


### PR DESCRIPTION
sys-libs/timezone-data-2018g became stable in Gentoo 10 days ago.
With the change to 'settzclock'  the installer-99999 on Pentoo ISO RC8 with previous timezone-data will still work.
Fix for #46