### PR TITLE
Put mokmanager efi image in /boot/efi/{Pentoo,boot}

### DIFF
--- a/share/pentoo-installer/bootloader_grub2
+++ b/share/pentoo-installer/bootloader_grub2
@@ -211,7 +211,9 @@ if [ -d /sys/firmware/efi ]; then
   if [ -r "/sys/firmware/efi/fw_platform_size" ] && [ "$(cat /sys/firmware/efi/fw_platform_size)" = "64" ]; then
     chroot "${DESTDIR}" /usr/sbin/grub-install -v --efi-directory=/boot --bootloader-id=Pentoo --themes=pentoo --target=x86_64-efi --recheck "${DISK_BOOT}" >/tmp/grub.log 2>&1 || exit $?
     cp "${DESTDIR}"/usr/share/shim/BOOTX64.EFI "${DESTDIR}"/boot/efi/Pentoo/BOOTX64.EFI || exit $?
+    # mokmanager efi image is sometimes required in /boot/efi/boot
     cp "${DESTDIR}"/usr/share/shim/mmx64.efi "${DESTDIR}"/boot/efi/Pentoo/mmx64.efi || exit $?
+    cp "${DESTDIR}"/usr/share/shim/mmx64.efi "${DESTDIR}"/boot/efi/boot/mmx64.efi || exit $?
     if [ "${efivars}" = "1" ]; then
       #the kernel cannnot handle 32 bit userland and 64 bit efi well, so we can't do this
       if efibootmgr | grep -q Pentoo; then
@@ -222,7 +224,9 @@ if [ -d /sys/firmware/efi ]; then
   elif [ -r "/sys/firmware/efi/fw_platform_size" ] && [ "$(cat /sys/firmware/efi/fw_platform_size)" = "32" ]; then
     chroot "${DESTDIR}" /usr/sbin/grub-install -v --efi-directory=/boot --bootloader-id=Pentoo --themes=pentoo --target=i386-efi --recheck "${DISK_BOOT}" >/tmp/grub.log 2>&1 || exit $?
     cp "${DESTDIR}"/usr/share/shim/BOOTIA32.EFI "${DESTDIR}"/boot/efi/Pentoo/BOOTIA32.EFI || exit $?
+    # mokmanager efi image is sometimes required in /boot/efi/boot
     cp "${DESTDIR}"/usr/share/shim/mmia32.efi "${DESTDIR}"/boot/efi/Pentoo/mmia32.efi || exit $?
+    cp "${DESTDIR}"/usr/share/shim/mmia32.efi "${DESTDIR}"/boot/efi/boot/mmia32.efi || exit $?
     if [ "${efivars}" = "1" ]; then
       if efibootmgr | grep -q Pentoo; then
         efibootmgr -B -b $(efibootmgr | grep Pentoo | awk -F'*' '{print $1}' | cut -b 5-8) || exit $?
@@ -232,7 +236,9 @@ if [ -d /sys/firmware/efi ]; then
   else
     chroot "${DESTDIR}" /usr/sbin/grub-install -v --efi-directory=/boot --bootloader-id=Pentoo --themes=pentoo --recheck "${DISK_BOOT}" >/tmp/grub.log 2>&1 || exit $?
     cp "${DESTDIR}"/usr/share/shim/BOOTX64.EFI "${DESTDIR}"/boot/efi/Pentoo/BOOTX64.EFI || exit $?
+    # mokmanager efi image is sometimes required in /boot/efi/boot
     cp "${DESTDIR}"/usr/share/shim/mmx64.efi "${DESTDIR}"/boot/efi/Pentoo/mmx64.efi || exit $?
+    cp "${DESTDIR}"/usr/share/shim/mmx64.efi "${DESTDIR}"/boot/efi/boot/mmx64.efi || exit $?
     if [ "${efivars}" = "1" ]; then
       if efibootmgr | grep -q Pentoo; then
         efibootmgr -B -b $(efibootmgr | grep Pentoo | awk -F'*' '{print $1}' | cut -b 5-8) || exit $?


### PR DESCRIPTION
On boot, the file was searched for in /boot/efi/boot
But previously it worked fine with the file in /boot/efi/Pentoo
Thus placing the file in both directories to make sure.

Fixes #52