### PR TITLE
Create /boot/efi/boot for 2nd mokmanager image

### DIFF
--- a/share/pentoo-installer/bootloader_grub2
+++ b/share/pentoo-installer/bootloader_grub2
@@ -211,8 +211,9 @@ if [ -d /sys/firmware/efi ]; then
   if [ -r "/sys/firmware/efi/fw_platform_size" ] && [ "$(cat /sys/firmware/efi/fw_platform_size)" = "64" ]; then
     chroot "${DESTDIR}" /usr/sbin/grub-install -v --efi-directory=/boot --bootloader-id=Pentoo --themes=pentoo --target=x86_64-efi --recheck "${DISK_BOOT}" >/tmp/grub.log 2>&1 || exit $?
     cp "${DESTDIR}"/usr/share/shim/BOOTX64.EFI "${DESTDIR}"/boot/efi/Pentoo/BOOTX64.EFI || exit $?
-    # mokmanager efi image is sometimes required in /boot/efi/boot
     cp "${DESTDIR}"/usr/share/shim/mmx64.efi "${DESTDIR}"/boot/efi/Pentoo/mmx64.efi || exit $?
+    # mokmanager efi image is sometimes required in /boot/efi/boot
+    mkdir -p "${DESTDIR}"/boot/efi/boot || exit $?
     cp "${DESTDIR}"/usr/share/shim/mmx64.efi "${DESTDIR}"/boot/efi/boot/mmx64.efi || exit $?
     if [ "${efivars}" = "1" ]; then
       #the kernel cannnot handle 32 bit userland and 64 bit efi well, so we can't do this
@@ -224,8 +225,9 @@ if [ -d /sys/firmware/efi ]; then
   elif [ -r "/sys/firmware/efi/fw_platform_size" ] && [ "$(cat /sys/firmware/efi/fw_platform_size)" = "32" ]; then
     chroot "${DESTDIR}" /usr/sbin/grub-install -v --efi-directory=/boot --bootloader-id=Pentoo --themes=pentoo --target=i386-efi --recheck "${DISK_BOOT}" >/tmp/grub.log 2>&1 || exit $?
     cp "${DESTDIR}"/usr/share/shim/BOOTIA32.EFI "${DESTDIR}"/boot/efi/Pentoo/BOOTIA32.EFI || exit $?
-    # mokmanager efi image is sometimes required in /boot/efi/boot
     cp "${DESTDIR}"/usr/share/shim/mmia32.efi "${DESTDIR}"/boot/efi/Pentoo/mmia32.efi || exit $?
+    # mokmanager efi image is sometimes required in /boot/efi/boot
+    mkdir -p "${DESTDIR}"/boot/efi/boot || exit $?
     cp "${DESTDIR}"/usr/share/shim/mmia32.efi "${DESTDIR}"/boot/efi/boot/mmia32.efi || exit $?
     if [ "${efivars}" = "1" ]; then
       if efibootmgr | grep -q Pentoo; then
@@ -236,8 +238,9 @@ if [ -d /sys/firmware/efi ]; then
   else
     chroot "${DESTDIR}" /usr/sbin/grub-install -v --efi-directory=/boot --bootloader-id=Pentoo --themes=pentoo --recheck "${DISK_BOOT}" >/tmp/grub.log 2>&1 || exit $?
     cp "${DESTDIR}"/usr/share/shim/BOOTX64.EFI "${DESTDIR}"/boot/efi/Pentoo/BOOTX64.EFI || exit $?
-    # mokmanager efi image is sometimes required in /boot/efi/boot
     cp "${DESTDIR}"/usr/share/shim/mmx64.efi "${DESTDIR}"/boot/efi/Pentoo/mmx64.efi || exit $?
+    # mokmanager efi image is sometimes required in /boot/efi/boot
+    mkdir -p "${DESTDIR}"/boot/efi/boot || exit $?
     cp "${DESTDIR}"/usr/share/shim/mmx64.efi "${DESTDIR}"/boot/efi/boot/mmx64.efi || exit $?
     if [ "${efivars}" = "1" ]; then
       if efibootmgr | grep -q Pentoo; then


### PR DESCRIPTION
Follow up to commit 5638f7e, sorry!
If /boot was empty, create /boot/efi/boot for
the second mokmanager image