### PR TITLE
copy_distro: fix typo

### DIFF
--- a/share/pentoo-installer/copy_distro
+++ b/share/pentoo-installer/copy_distro
@@ -172,7 +172,7 @@ auto_fstab() {
 		fi
 		if [ -n "${_CRYPTTYPE}" ]; then
 			if [ "${_FILESYSTEM}" = 'swap' ]; then
-				_PARTPATH="/dev/mapper/${CRYPTNAME}"
+				_PARTPATH="/dev/mapper/${_CRYPTNAME}"
 			else
 				_PARTPATH="UUID=$(blkid -s UUID -o value /dev/mapper/${_CRYPTNAME})"
 			fi


### PR DESCRIPTION
CRYPTNAME without leading _ does not exist in that script and must
be a typo. Thanks to ostree

Fixes #49