### PR TITLE
bug: Provide deterministic location to installer

### DIFF
--- a/share/pentoo-installer/pentoo-installer
+++ b/share/pentoo-installer/pentoo-installer
@@ -14,9 +14,16 @@
 # reason: show_dialog() needs a way to exit "Cancel"
 #
 
-#this really shouldn't fail, but somehow it did
-#readonly SHAREDIR="$(dirname ${0})/../share/pentoo-installer"
-readonly SHAREDIR="/usr/share/pentoo-installer"
+# This introspects the location of this script (pentoo-installer) in relation to
+# the structure of this repository and then builds a deterministic path to its
+# base location.
+#
+# It should be noted that both "dirname" and "realname" may encounter issues
+# when the installer is called with a path containing spaces in the event that
+# instances of ${SHAREDIR} are not properly quoted.  This combination of both
+# "dirname" and "realpath" should prove more robust to nuances with the
+# strucutres of paths in the future.
+readonly SHAREDIR="$(dirname "$(realpath -s "$0")")"
 
 # source common variables, functions and error handling
 # also get functions to save settings


### PR DESCRIPTION
Previously the installer was using the `dirname` utility in a common
pattern to establish the location of the installer. The goal was to
provide a durable mechanism for determining the location of "libraries"
used by this script.

Historically users attempting to achieve this would utilize the
`dirname` utility which strips the last non-directory component(s) from
a supplied set of arguments with the intention of providing solely the
leading path components.

Unfortunately a bug was experienced and this was modified in commit
c42f076febe660dee81cd20f31c8d83edb07101e

This reimplements the intended functionality while making it more robust
to nuances in the structuring of the path.

As of coreutils v8.15 (January 2012) a new utility has been added,
(`realpath`), which provides a more robust mechanism for determining the
full path to a file.

In this situation we first use `realpath` to establish the full path to
the called script (in this case, `pentoo-installer`) which is supplied
as $0 to the utility.  We also use the `-s` flag to ensure that we do
*NOT* attempt to fully resolve any symbolic links.  After establishing
this value, we then use combine it with `dirname` to remove the script
and trailing slashes to have the proper base path.  The interposed
quotes are there to ensure paths including spaces are properly
interpreted.